### PR TITLE
reduce docker image size by almost half

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,30 +1,38 @@
-FROM debian:stable
+ARG DEBIAN_FRONTEND=noninteractive
+FROM python:3.6 as builder
 
 LABEL maintainer "Manuel Muñoz <manuel.munoz@crg.eu>" \
       version "1.0" \
       description "Docker image for PyHIST"
 
 # Install necessary tools
-RUN export DEBIAN_FRONTEND=noninteractive && \
-	apt-get update --fix-missing -qq && \
+RUN apt-get update -qq && \
 	apt-get install -y -q \
-	build-essential \
 	libgl1-mesa-glx \
-	python3.6 \
-	python3-pip \
-	openslide-tools \
-	python3-openslide && \
-	pip3 install pandas opencv-python
+	openslide-tools
 
 # Copy PyHIST to container
-WORKDIR /pyhist
-COPY pyhist* /pyhist/
-ADD src /pyhist/src
+WORKDIR /opt/pyhist
+RUN python -m venv venv \
+	&& ./venv/bin/python -m pip install --no-cache-dir -U pip setuptools wheel \
+	&& ./venv/bin/python -m pip install --no-cache-dir pandas opencv-python openslide-python
+ENV PATH="/opt/pyhist/venv/bin:$PATH"
+COPY pyhist* .
+COPY src src
 
 # Compile segmentation algorithm
 RUN cd src/graph_segmentation/ && \
 	make && \
 	chmod 755 segment
 
-# Entrypoing
+# Build final, slim image.
+FROM python:3.6-slim
+RUN apt-get update -qq \
+	&& apt-get install -y -q \
+		libgl1-mesa-glx \
+		libopenslide0 \
+	&& rm -rf /var/lib/apt/lists/*
+WORKDIR /opt/pyhist
+COPY --from=builder /opt/pyhist .
+ENV PATH="/opt/pyhist/venv/bin:$PATH"
 ENTRYPOINT ["python3", "pyhist.py"]


### PR DESCRIPTION
thank you for making this package -- it's exactly what i need :)

This commit substantially reduces the size of the docker image by using
multi-stage builds. This allows us to build the software in the first
stage and copy the built artifacts into the second, final stage. We only
install runtime dependencies into the second stage. We also use a python
base image so that python/pip are already available in the image.